### PR TITLE
Set RHI Operator default namespace to 'redhat-rhi-operator'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include ./make/*.mk
 
 ORG=integreatly
-NAMESPACE=redhat-rhmi-operator
+NAMESPACE=redhat-rhi-operator
 PROJECT=integreatly-operator
 REG=quay.io
 SHELL=/bin/bash

--- a/deploy/crds/examples/rhmi.cr.yaml
+++ b/deploy/crds/examples/rhmi.cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-rhmi
 spec:
   type: managed
-  namespacePrefix: redhat-rhmi-
+  namespacePrefix: redhat-rhi-
   selfSignedCerts: true
   useClusterStorage: 'true'
   smtpSecret: redhat-rhmi-smtp

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: rhmi-operator
-  namespace: redhat-rhmi-operator
+  namespace: redhat-rhi-operator
 roleRef:
   kind: Role
   name: rhmi-operator
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rhmi-operator
-    namespace: redhat-rhmi-operator
+    namespace: redhat-rhi-operator
 roleRef:
   kind: ClusterRole
   name: rhmi-operator


### PR DESCRIPTION
https://issues.redhat.com/browse/IPT-22

Notes:
- changed role_binding.yaml to a template file
- refactored the Makefile cluster/cleanup target to avoid errors due to trying to delete objects already deleted via prior namespace deletion and included the deletion of CRDs to fully clean up what's created during the cluster/prepare/local target