### PR TITLE
IPT-15: updating OWNERS entries for rhi-operator project

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,29 +1,10 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- mikenairn
-- maleck13
-- philbrookes
-- davidffrench
-- matskiv
-- david-martin
+- jeremyary
+- akieling
 
 reviewers:
-- mikenairn
-- maleck13
-- philbrookes
-- aidenkeating
-- dimitraz
-- matskiv
-- JameelB
-- trepel
-- austincunningham
-- pmccarthy
-- damienomurchu
-- jjaferson
-- kevfan
-- david-martin
-- davidffrench
-- pawelpaszki
-- grdryn
-- briangallagher
+- jeremyary
+- akieling
+- akoserwal

--- a/openshift-ci/OWNERS
+++ b/openshift-ci/OWNERS
@@ -1,9 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- mikenairn
-- pmccarthy
-- tremes
-- maleck13
-- philbrookes
-- grdryn
+- jeremyary
+- akieling
+- akoserwal

--- a/scripts/ci/OWNERS
+++ b/scripts/ci/OWNERS
@@ -1,9 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- mikenairn
-- pmccarthy
-- tremes
-- maleck13
-- philbrookes
-- grdryn
+- jeremyary
+- akoserwal
+- akieling

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,14 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- mikenairn
-- pmccarthy
-- maleck13
-- philbrookes
-- grdryn
-- david-martin
-- psturc
-- jhellar
-- b1zzu
-- pawelpaszki
-- damienomurchu
+- jeremyary
+- akieling
+- akoserwal


### PR DESCRIPTION
# Description
update to various OWNERS files to align with new project team for fork
https://issues.redhat.com/browse/IPT-15