### PR TITLE
add UTC conversion to test timestamp to align with code comparison

### DIFF
--- a/pkg/controller/subscription/rhmiConfigs/main_test.go
+++ b/pkg/controller/subscription/rhmiConfigs/main_test.go
@@ -34,7 +34,7 @@ func buildScheme() *runtime.Scheme {
 }
 
 func nowOffset(hours int) time.Time {
-	now := time.Now()
+	now := time.Now().UTC()
 	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour()+hours, now.Minute(), now.Second(), 0, time.UTC)
 }
 


### PR DESCRIPTION
# Description
Currently, test cases regarding maintenance time windows will fail for anyone with local time far enough away from UTC. Without .UTC() conversion, time.Now() will always be outside the expected window and cause failures if the local UTC difference is large enough.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works