### PR TITLE
[WIP] temporarily re-enable CR creation w/self-managed type for e2e

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48,5 +48,10 @@ spec:
               value: "rhmi-operator"
             - name: USE_CLUSTER_STORAGE
               value: "true"
+            # setting to true to allow CR creation until e2e automation is in place
+            # (we want customers to create their CR's down the road, but e2e is not making one yet)
             - name: AUTO_INSTALL_AT_STARTUP
-              value: "false"
+              value: "true"
+            # with CR creation temporarily in place, the type again becomes relevant until e2e creation is automated
+            - name: INSTALLATION_TYPE
+                value: "self-managed"

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -149,8 +149,9 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 
 		useClusterStorage, _ := os.LookupEnv("USE_CLUSTER_STORAGE")
 		alertingEmailAddress, _ := os.LookupEnv("ALERTING_EMAIL_ADDRESS")
+		installationType, _ := os.LookupEnv("INSTALLATION_TYPE")
 
-		logrus.Infof("Creating a %s rhmi CR with USC %s, as no CR rhmis were found in %s namespace", string(integreatlyv1alpha1.InstallationTypeManaged), useClusterStorage, namespace)
+		logrus.Infof("Creating a %s rhmi CR with USC %s, as no CR rhmis were found in %s namespace", installationType, useClusterStorage, namespace)
 
 		installation = &integreatlyv1alpha1.RHMI{
 			ObjectMeta: metav1.ObjectMeta{
@@ -158,7 +159,7 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 				Namespace: namespace,
 			},
 			Spec: integreatlyv1alpha1.RHMISpec{
-				Type:                        string(integreatlyv1alpha1.InstallationTypeManaged),
+				Type:                        installationType,
 				NamespacePrefix:             DefaultInstallationPrefix,
 				SelfSignedCerts:             false,
 				SMTPSecret:                  DefaultInstallationPrefix + "smtp",


### PR DESCRIPTION
# Description
[PR-28](https://github.com/redhat-integration/rhi-operator/pull/28) introduces a logic check around programmatic creation of the CR resource and disables such for self-managed profile installations. However, e2e is not yet capable of generating a CR to simulate that which a customer would create, therefore, no products get installed and tests will fail. 

Temporarily adding back the INSTALLATION_TYPE var & re-enabling CR creation by default while we work on e2e process CR creation. Choosing to add back the var rather than roll back the previously mentioned PR as that change is good for the long-term and does not hurt to have inclusion.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)