### PR TITLE
INSTALLATION_TYPE to self-managed for e2e/make processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
 endif
 
 export SELF_SIGNED_CERTS   ?= true
-export INSTALLATION_TYPE   ?= managed
+export INSTALLATION_TYPE   ?= self-managed
 export INSTALLATION_NAME   ?= rhmi
 export INSTALLATION_PREFIX ?= redhat-rhmi
 export USE_CLUSTER_STORAGE ?= true


### PR DESCRIPTION
# Description
Changing the INSTALLATION_TYPE to self-managed to enable our own suite of e2e testing