### PR TITLE
IPT-80 [RHI Op] Metering Labels for all the images

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -11,6 +11,11 @@ spec:
     metadata:
       labels:
         name: rhmi-operator
+        com.redhat.product-name: Red_Hat_Integration
+        com.redhat.product-version: ""
+        com.redhat.component-name: rhi-operator
+        com.redhat.component-version: ""
+        com.redhat.component-type: infrastructure
     spec:
       serviceAccountName: rhmi-operator
       volumes:


### PR DESCRIPTION
Added labels to pods created a a result of the operator deployment.
More details here: https://issues.redhat.com/browse/IPT-80