### PR TITLE
bumping operator-sdk version 17.0 to 17.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5
 	github.com/operator-framework/operator-marketplace v0.0.0-20191105191618-530c85d41ce7
 	github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52c19a
-	github.com/operator-framework/operator-sdk v0.17.0
+	github.com/operator-framework/operator-sdk v0.17.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.3.0
 	github.com/sirupsen/logrus v1.6.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -506,7 +506,7 @@ github.com/operator-framework/operator-registry/pkg/lib/bundle
 github.com/operator-framework/operator-registry/pkg/registry
 github.com/operator-framework/operator-registry/pkg/sqlite
 github.com/operator-framework/operator-registry/pkg/sqlite/migrations
-# github.com/operator-framework/operator-sdk v0.17.0 => github.com/operator-framework/operator-sdk v0.15.1
+# github.com/operator-framework/operator-sdk v0.17.2 => github.com/operator-framework/operator-sdk v0.15.1
 github.com/operator-framework/operator-sdk/cmd/operator-sdk
 github.com/operator-framework/operator-sdk/cmd/operator-sdk/add
 github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Error: flag redefined: kubeconfig
With recent changes pulled has introduced
``` 
testingContext := &common.TestingContext{
		Client:          f.Client.Client,
		KubeConfig:      f.KubeConfig,
		KubeClient:      f.KubeClient,
		ExtensionClient: apiextensions,
		SelfSignedCerts: selfSignedCerts,
	}
```

https://github.com/redhat-integration/rhi-operator/blob/master/test/e2e/integreatly_test.go#L76

operator-sdk v17.0 has defined kubeconfig flag which causing this failure.
v17.2 has the condition flag skip re-introduce the kubeconfig flag to https://github.com/operator-framework/operator-sdk/blob/v0.17.2/pkg/test/main_entry.go#L33




- [X] Bug fix (non-breaking change which fixes an issue)


