### PR TITLE
downgrade apicurio-registry-operator to version 0.0.2

### DIFF
--- a/manifests/integreatly-apicurio-registry/1.0.0/apicurio-registry-operator.v1.0.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-apicurio-registry/1.0.0/apicurio-registry-operator.v1.0.0.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     containerImage: 'apicurio/apicurio-registry-operator:latest'
     support: 'Apicurio Project'
     capabilities: Basic Install
-    repository: 'docker.io/apicurio/apicurio-registry-operator:0.0.3-dev'
+    repository: 'docker.io/apicurio/apicurio-registry-operator:0.0.2'
 spec:
   displayName: Apicurio Registry Operator
   description: >
@@ -252,7 +252,7 @@ spec:
                 serviceAccountName: apicurio-registry
                 containers:
                   - name: apicurio-registry
-                    image: 'docker.io/apicurio/apicurio-registry-operator:0.0.3-dev'
+                    image: 'docker.io/apicurio/apicurio-registry-operator:0.0.2'
                     imagePullPolicy: Always
                     env:
                       - name:  REGISTRY_IMAGE_STREAMS


### PR DESCRIPTION
# Description
docker.io/apicurio/apicurio-registry-operator:0.0.3-dev is unstable and sometimes buggy.
Downgrading to docker.io/apicurio/apicurio-registry-operator:0.0.2 for a more stable deployment.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer